### PR TITLE
Avoid FSDP parameter flattening to reduce memory spikes

### DIFF
--- a/train/fsdp_utils.py
+++ b/train/fsdp_utils.py
@@ -132,6 +132,7 @@ def fsdp_wrapper(
         backward_prefetch=BackwardPrefetch[fsdp_config.backward_prefetch],
         cpu_offload=CPUOffload(offload_params=cpu_offload),
         device_mesh=device_mesh,
+        use_orig_params=True,
     )
 
 


### PR DESCRIPTION
## Summary
- configure the FSDP wrapper to keep original parameters instead of flattening them, preventing large temporary allocations during wrapping

## Testing
- python -m compileall train/fsdp_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ca135e91a48323b1bd057e27901182