### PR TITLE
Update example config to use breast edit dataset

### DIFF
--- a/data/configs/example.yaml
+++ b/data/configs/example.yaml
@@ -1,15 +1,3 @@
-t2i_pretrain:
-  dataset_names:
-  - t2i
-  image_transform_args:
-    image_stride: 16
-    max_image_size: 1024
-    min_image_size: 512
-  is_mandatory: true
-  num_used_data: # The sum should be larger that NUM_GPUS x NUM_WORKERS
-  - 10
-  weight: 1
-
 unified_edit:
   dataset_names:
   - breast_edit
@@ -24,21 +12,3 @@ unified_edit:
     image_stride: 14
     max_image_size: 518
     min_image_size: 224
-
-vlm_sft:
-  dataset_names:
-  - llava_ov
-  image_transform_args:
-    image_stride: 14
-    max_image_size: 980
-    min_image_size: 378
-    max_pixels: 2_007_040
-  frame_sampler_args:
-    max_num_frames: 12
-    min_num_frames: 8
-  is_mandatory: true
-  shuffle_lines: True
-  shuffle_seed: 0
-  num_used_data:
-  - 1000
-  weight: 1


### PR DESCRIPTION
## Summary
- remove the placeholder t2i and vlm_sft dataset groups from the example config
- keep only the breast_edit unified_edit dataset so training uses the provided editing parquet files

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca17faa00c83238952d1d5ed516770