### PR TITLE
Gracefully handle missing CE loss during visual understanding training

### DIFF
--- a/train/pretrain_unified_navit.py
+++ b/train/pretrain_unified_navit.py
@@ -604,8 +604,11 @@ def main():
             loss_dict["ce"] = ce.detach()
             loss = loss + ce * training_args.ce_weight
         else:
-            assert not training_args.visual_und
-            loss_dict["ce"] = torch.tensor(0, device=device)
+            if training_args.visual_und:
+                logger.warning(
+                    "Received no CE loss despite visual_und=True; skipping CE loss for this batch."
+                )
+            loss_dict["ce"] = torch.tensor(0.0, device=device)
             total_ce_tokens = torch.tensor(0, device=device)
 
         if training_args.visual_gen:


### PR DESCRIPTION
## Summary
- avoid aborting training when no CE loss is returned while visual_und is enabled
- log a warning and continue with a zero CE loss tensor so generation-only data can be used safely

## Testing
- python -m compileall train/pretrain_unified_navit.py

------
https://chatgpt.com/codex/tasks/task_e_68ca2434b4d48323a7879c1f321c82a7