### PR TITLE
Reduce MoE MLP memory usage with chunked forward

### DIFF
--- a/modeling/qwen2/configuration_qwen2.py
+++ b/modeling/qwen2/configuration_qwen2.py
@@ -101,6 +101,9 @@ class Qwen2Config(PretrainedConfig):
             The number of layers that use SWA (Sliding Window Attention). The bottom layers use SWA while the top use full attention.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
+        moe_mlp_chunk_size (`int`, *optional*, defaults to 2048):
+            Split size (in tokens) used to compute the MoE MLP projection in smaller chunks during training
+            and inference. Set to a non-positive value to disable chunking.
 
     ```python
     >>> from transformers import Qwen2Model, Qwen2Config
@@ -140,6 +143,7 @@ class Qwen2Config(PretrainedConfig):
         attention_dropout=0.0,
         is_causal=True,
         _attn_implementation="flash_attention_2",
+        moe_mlp_chunk_size=2048,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -166,6 +170,7 @@ class Qwen2Config(PretrainedConfig):
         self.attention_dropout = attention_dropout
         self.is_causal = is_causal
         self._attn_implementation = _attn_implementation
+        self.moe_mlp_chunk_size = moe_mlp_chunk_size
 
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, move it to 'rope_type'.


### PR DESCRIPTION
## Summary
- add a reusable helper to run the generation MoE MLP in configurable chunks and apply it across MoT/MoE decoder training and inference paths to lower activation peaks
- extend the Qwen2 config with a `moe_mlp_chunk_size` option (defaulting to 2048) so chunk sizing is centrally managed and serialized

## Testing
- python -m compileall modeling/bagel/qwen2_navit.py modeling/qwen2/configuration_qwen2.py

------
https://chatgpt.com/codex/tasks/task_e_68ca292f86dc8323b00e7163d93e6451