### PR TITLE
Fix distributed dataset sharding and add regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ results
 *.ipynb_checkpoints
 eval_results
 tests
+!tests/
+tests/__pycache__/
+!tests/__init__.py
+!tests/test_distributed_iterable_dataset.py
 .DS_Store
 gradio.sh

--- a/data/distributed_iterable_dataset.py
+++ b/data/distributed_iterable_dataset.py
@@ -1,8 +1,14 @@
 # Copyright 2025 Bytedance Ltd. and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+import math
 import random
+
 import torch
+
+
+logger = logging.getLogger(__name__)
 
 
 class DistributedIterableDataset(torch.utils.data.IterableDataset):
@@ -31,11 +37,29 @@ class DistributedIterableDataset(torch.utils.data.IterableDataset):
         self.rng.seed(seed)
         self.rng.shuffle(data_paths)
 
-        num_files_per_rank = len(data_paths) // self.world_size
-        local_start = self.local_rank * num_files_per_rank
-        local_end = (self.local_rank + 1) * num_files_per_rank
-        self.num_files_per_rank = num_files_per_rank
-        self.data_paths_per_rank = data_paths[local_start:local_end]
+        total_files = len(data_paths)
+        if total_files == 0:
+            self.num_files_per_rank = 0
+            self.data_paths_per_rank = []
+            return
+
+        if self.world_size <= 0:
+            raise ValueError("world_size must be a positive integer")
+
+        if total_files < self.world_size:
+            logger.warning(
+                "Dataset %s has %d shards but world_size=%d; reusing shards to cover all ranks.",
+                self.dataset_name,
+                total_files,
+                self.world_size,
+            )
+            repeat_factor = math.ceil(self.world_size / total_files)
+            data_paths = data_paths * repeat_factor
+            self.rng.shuffle(data_paths)
+
+        per_rank_splits = self._balanced_split(data_paths, self.world_size, ensure_non_empty=True)
+        self.data_paths_per_rank = per_rank_splits[self.local_rank]
+        self.num_files_per_rank = len(self.data_paths_per_rank)
 
     def get_data_paths_per_worker(self):
         if self.data_paths is None:
@@ -47,12 +71,40 @@ class DistributedIterableDataset(torch.utils.data.IterableDataset):
             return self.data_paths_per_rank, 0
 
         worker_id = info.id
-        num_files_per_worker = self.num_files_per_rank // info.num_workers
-        start = num_files_per_worker * worker_id
-        end = num_files_per_worker * (worker_id + 1)
-        data_paths_per_worker = self.data_paths_per_rank[start:end]
+        if info.num_workers <= 0:
+            raise ValueError("num_workers must be a positive integer")
+
+        per_worker_splits = self._balanced_split(
+            self.data_paths_per_rank,
+            info.num_workers,
+            ensure_non_empty=bool(self.data_paths_per_rank),
+        )
+        data_paths_per_worker = per_worker_splits[worker_id]
 
         return data_paths_per_worker[::-1], worker_id
 
     def __iter__(self):
         raise NotImplementedError
+
+    def _balanced_split(self, items, num_splits, ensure_non_empty=False):
+        if num_splits <= 0:
+            raise ValueError("num_splits must be a positive integer")
+
+        items = list(items)
+        if not items:
+            return [[] for _ in range(num_splits)]
+
+        if ensure_non_empty and len(items) < num_splits:
+            repeat_factor = math.ceil(num_splits / len(items))
+            items = items * repeat_factor
+
+        base, remainder = divmod(len(items), num_splits)
+        splits = []
+        start = 0
+        for idx in range(num_splits):
+            chunk_size = base + (1 if idx < remainder else 0)
+            end = start + chunk_size
+            splits.append(items[start:end])
+            start = end
+
+        return splits

--- a/tests/test_distributed_iterable_dataset.py
+++ b/tests/test_distributed_iterable_dataset.py
@@ -1,0 +1,108 @@
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+try:  # pragma: no cover - optional torch dependency for tests
+    import torch  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    import types
+
+    torch = types.ModuleType("torch")
+    utils_module = types.ModuleType("torch.utils")
+    data_module = types.ModuleType("torch.utils.data")
+
+    class _IterableDataset:  # minimal stub for testing
+        pass
+
+    def _get_worker_info():
+        return None
+
+    data_module.IterableDataset = _IterableDataset
+    data_module.get_worker_info = _get_worker_info
+    utils_module.data = data_module
+    torch.utils = utils_module
+
+    sys.modules.setdefault("torch", torch)
+    sys.modules.setdefault("torch.utils", utils_module)
+    sys.modules.setdefault("torch.utils.data", data_module)
+
+from data.distributed_iterable_dataset import DistributedIterableDataset
+
+
+class DummyLoopDataset(DistributedIterableDataset):
+    def __init__(self, data_paths, dataset_name="dummy", local_rank=0, world_size=1, num_workers=1, max_loops=2):
+        super().__init__(dataset_name, local_rank=local_rank, world_size=world_size, num_workers=num_workers)
+        self.max_loops = max_loops
+        self.data_paths = list(data_paths)
+        self.set_epoch()
+
+    def __iter__(self):
+        data_paths_per_worker, worker_id = self.get_data_paths_per_worker()
+        loops = 0
+        while loops < self.max_loops:
+            for path in data_paths_per_worker:
+                yield (worker_id, path)
+            print(f"{self.dataset_name} repeat in rank-{self.local_rank} worker-{worker_id}")
+            loops += 1
+
+
+class DistributedIterableDatasetTest(unittest.TestCase):
+    def test_ranks_and_workers_receive_data(self):
+        data_paths = ["file0"]
+        world_size = 4
+        num_workers = 3
+
+        for local_rank in range(world_size):
+            dataset = DummyLoopDataset(
+                data_paths,
+                dataset_name="regression",
+                local_rank=local_rank,
+                world_size=world_size,
+                num_workers=num_workers,
+            )
+            dataset.set_epoch(seed=0)
+            self.assertGreater(
+                len(dataset.data_paths_per_rank),
+                0,
+                msg=f"Rank {local_rank} did not receive any data paths",
+            )
+
+            for worker_id in range(num_workers):
+                worker_info = SimpleNamespace(id=worker_id, num_workers=num_workers)
+                with patch("torch.utils.data.get_worker_info", return_value=worker_info):
+                    data_paths_per_worker, reported_worker_id = dataset.get_data_paths_per_worker()
+
+                self.assertEqual(worker_id, reported_worker_id)
+                self.assertGreater(
+                    len(data_paths_per_worker),
+                    0,
+                    msg=f"Worker {worker_id} on rank {local_rank} received no data paths",
+                )
+
+    def test_iterator_yields_before_repeat(self):
+        data_paths = ["file0"]
+        world_size = 4
+        num_workers = 3
+        dataset = DummyLoopDataset(
+            data_paths,
+            dataset_name="regression",
+            local_rank=0,
+            world_size=world_size,
+            num_workers=num_workers,
+            max_loops=2,
+        )
+        dataset.set_epoch(seed=123)
+
+        worker_info = SimpleNamespace(id=1, num_workers=num_workers)
+        with patch("torch.utils.data.get_worker_info", return_value=worker_info):
+            with patch("builtins.print") as mock_print:
+                iterator = iter(dataset)
+                first_item = next(iterator)
+
+        self.assertEqual(first_item, (1, "file0"))
+        mock_print.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- balance shard assignment in `DistributedIterableDataset` by reusing files when world size or worker count exceeds available paths
- add a helper splitter that keeps every rank/worker non-empty and warn when shards must be repeated
- add a regression test harness (with a lightweight torch stub) to ensure ranks and workers still yield samples instead of spinning on repeat

## Testing
- python -m unittest tests.test_distributed_iterable_dataset

------
https://chatgpt.com/codex/tasks/task_e_68ca3accbf24832389578eb8911eb8c3