### PR TITLE
Add breast edit dataset config

### DIFF
--- a/data/configs/breast_edit.yaml
+++ b/data/configs/breast_edit.yaml
@@ -1,0 +1,14 @@
+unified_edit:
+  dataset_names: [breast_edit]
+  num_used_data: [1]
+  weight: 1
+
+  image_transform_args:
+    image_stride: 16
+    max_image_size: 512
+    min_image_size: 256
+
+  vit_image_transform_args:
+    image_stride: 14
+    max_image_size: 350
+    min_image_size: 224

--- a/data/dataset_info.py
+++ b/data/dataset_info.py
@@ -19,5 +19,12 @@ DATASET_REGISTRY = {
 #     "parquet_info_path": "/abs/path/to/parquet_info.json",
 # }
 DATASET_INFO = {
-    'unified_edit': {},
+    'unified_edit': {
+        'breast_edit': {
+            "data_dir": "/workspace/qwen-image-training/data/breast-edit-dataset/parquet",
+            "num_files": 1,
+            "num_total_samples": 52,
+            "parquet_info_path": "/workspace/qwen-image-training/data/breast-edit-dataset/parquet_info.json",
+        },
+    },
 }


### PR DESCRIPTION
## Summary
- register the breast_edit dataset with its parquet directory and metadata
- add a dedicated breast_edit data config that mirrors the recommended edit-only transforms

## Testing
- python -m compileall data/dataset_info.py

------
https://chatgpt.com/codex/tasks/task_e_68ca50649194832395ec89ecb16f838b