### PR TITLE
Add Bagel inference scaffolding for breast edit dataset

### DIFF
--- a/bagel_infer/__init__.py
+++ b/bagel_infer/__init__.py
@@ -1,0 +1,21 @@
+"""Utility helpers for Bagel inference."""
+
+from .factory import (
+    InferenceProcessors,
+    build_model,
+    build_processors,
+    load_checkpoint,
+    resolve_checkpoint_dir,
+)
+from .pipeline import predict_single_edit, run_batch, glob_pairs
+
+__all__ = [
+    "InferenceProcessors",
+    "build_model",
+    "build_processors",
+    "load_checkpoint",
+    "resolve_checkpoint_dir",
+    "predict_single_edit",
+    "run_batch",
+    "glob_pairs",
+]

--- a/bagel_infer/factory.py
+++ b/bagel_infer/factory.py
@@ -1,0 +1,197 @@
+"""Factory helpers for constructing Bagel inference components."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import torch
+
+from data.data_utils import add_special_tokens
+from data.transforms import ImageTransform
+from modeling.autoencoder import load_ae
+from modeling.bagel import (
+    Bagel,
+    BagelConfig,
+    Qwen2Config,
+    Qwen2ForCausalLM,
+    SiglipVisionConfig,
+    SiglipVisionModel,
+)
+from modeling.qwen2 import Qwen2Tokenizer
+
+
+@dataclass
+class InferenceProcessors:
+    """Container with reusable preprocessing utilities for inference."""
+
+    tokenizer: Qwen2Tokenizer
+    new_token_ids: Dict[str, int]
+    vae_transform: ImageTransform
+    vit_transform: ImageTransform
+
+
+def _find_checkpoint_files(ckpt_dir: str) -> Tuple[Optional[str], Optional[str]]:
+    """Return candidate (ema, main) checkpoint files inside *ckpt_dir*."""
+
+    candidates = [
+        "ema.safetensors",
+        "model_ema.safetensors",
+        "model.safetensors",
+        "pytorch_model.bin",
+        "model.pt",
+        "full_state_dict.pt",
+    ]
+    found = [p for p in Path(ckpt_dir).glob("*") if p.name in candidates]
+    ema = next((str(p) for p in found if "ema" in p.name), None)
+    main = next((str(p) for p in found if "ema" not in p.name), None)
+    return ema, main
+
+
+def _latest_checkpoint_dir(root: str) -> str:
+    """Return the numerically latest checkpoint directory inside *root*."""
+
+    dirs = [p for p in Path(root).glob("[0-9][0-9][0-9][0-9][0-9][0-9]") if p.is_dir()]
+    if not dirs:
+        raise FileNotFoundError(f"No step subdirs found in {root}")
+    return str(sorted(dirs, key=lambda p: int(p.name))[-1])
+
+
+def resolve_checkpoint_dir(checkpoint_root: str, step: Optional[int]) -> str:
+    """Resolve a checkpoint directory given an optional *step* override."""
+
+    if step is None:
+        return _latest_checkpoint_dir(checkpoint_root)
+    return os.path.join(checkpoint_root, f"{step:07d}")
+
+
+def load_checkpoint(model: torch.nn.Module, ckpt: str) -> None:
+    """Load model weights from *ckpt* (file or directory).
+
+    Prefers EMA weights when present.
+    """
+
+    if os.path.isdir(ckpt):
+        ema, main = _find_checkpoint_files(ckpt)
+        ckpt_path = ema or main
+        if ckpt_path is None:
+            raise FileNotFoundError(f"No model weights found under {ckpt}")
+    else:
+        ckpt_path = ckpt
+
+    ext = os.path.splitext(ckpt_path)[1]
+    if ext == ".safetensors":
+        from safetensors.torch import load_file
+
+        state_dict = load_file(ckpt_path)
+    else:
+        state_dict = torch.load(ckpt_path, map_location="cpu")
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    print(f"[load_checkpoint] loaded {ckpt_path}")
+    if missing:
+        print(f"[load_checkpoint] missing keys: {len(missing)} (ok if frozen parts)")
+    if unexpected:
+        print(f"[load_checkpoint] unexpected keys: {len(unexpected)} (likely optimizer/FSDP)")
+
+
+def build_processors(
+    llm_path: str,
+    *,
+    vae_kwargs: Optional[Dict[str, int]] = None,
+    vit_kwargs: Optional[Dict[str, int]] = None,
+) -> InferenceProcessors:
+    """Build tokenizer + image transforms used during inference."""
+
+    tokenizer = Qwen2Tokenizer.from_pretrained(llm_path)
+    tokenizer, new_token_ids, _ = add_special_tokens(tokenizer)
+
+    vae_defaults = dict(image_stride=16, max_image_size=512, min_image_size=256)
+    vit_defaults = dict(image_stride=14, max_image_size=350, min_image_size=224)
+    if vae_kwargs:
+        vae_defaults.update(vae_kwargs)
+    if vit_kwargs:
+        vit_defaults.update(vit_kwargs)
+
+    vae_transform = ImageTransform(**vae_defaults)
+    vit_transform = ImageTransform(**vit_defaults)
+
+    return InferenceProcessors(
+        tokenizer=tokenizer,
+        new_token_ids=new_token_ids,
+        vae_transform=vae_transform,
+        vit_transform=vit_transform,
+    )
+
+
+def _load_llm_config(model_path: str, llm_path: str) -> Qwen2Config:
+    cfg_path = Path(model_path) / "llm_config.json"
+    if cfg_path.exists():
+        return Qwen2Config.from_json_file(str(cfg_path))
+    return Qwen2Config.from_pretrained(llm_path)
+
+
+def _load_vit_config(model_path: str, vit_path: str) -> SiglipVisionConfig:
+    cfg_path = Path(model_path) / "vit_config.json"
+    if cfg_path.exists():
+        return SiglipVisionConfig.from_json_file(str(cfg_path))
+    return SiglipVisionConfig.from_pretrained(vit_path)
+
+
+def _load_bagel_config(model_path: str) -> Optional[BagelConfig]:
+    cfg_path = Path(model_path) / "config.json"
+    if cfg_path.exists():
+        try:
+            return BagelConfig.from_json_file(str(cfg_path))
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+def build_model(
+    *,
+    model_path: str,
+    llm_path: str,
+    vit_path: str,
+    vae_path: str,
+    device: str = "cuda",
+    max_latent_size: int = 64,
+    latent_patch_size: int = 2,
+    vit_max_num_patch_per_side: int = 30,
+) -> Bagel:
+    """Instantiate the Bagel model for inference."""
+
+    torch.set_grad_enabled(False)
+    device_obj = torch.device(device if device != "cuda" or torch.cuda.is_available() else "cpu")
+
+    llm_config = _load_llm_config(model_path, llm_path)
+    vit_config = _load_vit_config(model_path, vit_path)
+    vae_model, vae_config = load_ae(vae_path)
+
+    bagel_config = _load_bagel_config(model_path) or BagelConfig()
+    bagel_config.visual_gen = True
+    bagel_config.visual_und = True
+    bagel_config.llm_config = llm_config
+    bagel_config.vit_config = vit_config
+    bagel_config.vae_config = vae_config
+    bagel_config.latent_patch_size = latent_patch_size
+    bagel_config.max_latent_size = max_latent_size
+    bagel_config.vit_max_num_patch_per_side = vit_max_num_patch_per_side
+
+    language_model = Qwen2ForCausalLM.from_pretrained(llm_path, config=llm_config)
+    vit_model = SiglipVisionModel.from_pretrained(vit_path, config=vit_config)
+    if hasattr(vit_model, "vision_model") and hasattr(vit_model.vision_model, "embeddings"):
+        converter = getattr(vit_model.vision_model.embeddings, "convert_conv2d_to_linear", None)
+        if callable(converter):
+            converter(vit_config)
+
+    model = Bagel(language_model, vit_model, bagel_config)
+    model.eval().to(device_obj)
+
+    vae_model = vae_model.to(device_obj).eval()
+    model.vae_model = vae_model
+    model.to(device_obj)
+
+    return model

--- a/bagel_infer/pipeline.py
+++ b/bagel_infer/pipeline.py
@@ -1,0 +1,248 @@
+"""Inference pipelines for Bagel reference-guided editing."""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import torch
+from PIL import Image
+
+from data.data_utils import pil_img2rgb
+from modeling.bagel.qwen2_navit import NaiveCache
+
+from .factory import InferenceProcessors
+
+
+def load_image(path: str) -> Image.Image:
+    """Load an image from *path* as RGB."""
+
+    image = Image.open(path)
+    return pil_img2rgb(image)
+
+
+def _move_to_device(inputs: Dict[str, torch.Tensor], device: torch.device) -> Dict[str, torch.Tensor]:
+    for key, value in inputs.items():
+        if torch.is_tensor(value):
+            inputs[key] = value.to(device)
+    return inputs
+
+
+def _clone_context(context: Dict[str, object]) -> Dict[str, object]:
+    return {
+        "kv_lens": list(context["kv_lens"]),
+        "ropes": list(context["ropes"]),
+        "past_key_values": deepcopy(context["past_key_values"]),
+    }
+
+
+def _decode_latent(latent: torch.Tensor, image_shape: Tuple[int, int], model) -> Image.Image:
+    H, W = image_shape
+    h = H // model.latent_downsample
+    w = W // model.latent_downsample
+    latent_patch = model.latent_patch_size
+    latent_channel = model.latent_channel
+
+    latent = latent.reshape(1, h, w, latent_patch, latent_patch, latent_channel)
+    latent = torch.einsum("nhwpqc->nchpwq", latent)
+    latent = latent.reshape(1, latent_channel, h * latent_patch, w * latent_patch)
+    image = model.vae_model.decode(latent)
+    image = (image * 0.5 + 0.5).clamp(0, 1)[0].permute(1, 2, 0).mul(255.0)
+    image = image.to(torch.uint8).cpu().numpy()
+    return Image.fromarray(image)
+
+
+@torch.no_grad()
+def predict_single_edit(
+    model,
+    processors: InferenceProcessors,
+    ref_path: str,
+    input_path: str,
+    *,
+    device: str = "cuda",
+    fp16: bool = True,
+    num_timesteps: int = 30,
+    cfg_text_scale: float = 1.0,
+    cfg_img_scale: float = 1.0,
+    cfg_interval: Tuple[float, float] = (0.0, 1.0),
+) -> Image.Image:
+    """Generate an edited prediction for a single (reference, input) pair."""
+
+    if device == "cuda" and not torch.cuda.is_available():
+        device = "cpu"
+    device_obj = torch.device(device)
+
+    model = model.to(device_obj)
+    model.eval()
+    if not hasattr(model, "vae_model"):
+        raise AttributeError("Model is missing attached VAE model; call build_model first")
+    model.vae_model = model.vae_model.to(device_obj).eval()
+
+    amp_dtype = torch.bfloat16 if fp16 and device_obj.type == "cuda" else torch.float32
+
+    input_image = load_image(input_path)
+    ref_image = load_image(ref_path)
+
+    main_context: Dict[str, object] = {
+        "kv_lens": [0],
+        "ropes": [0],
+        "past_key_values": NaiveCache(model.config.llm_config.num_hidden_layers),
+    }
+
+    def _update_context(image):
+        nonlocal main_context
+        past_key_values = main_context["past_key_values"]
+        kv_lens = main_context["kv_lens"]
+        ropes = main_context["ropes"]
+
+        generation_input, kv_lens, ropes = model.prepare_vae_images(
+            curr_kvlens=kv_lens,
+            curr_rope=ropes,
+            images=[image],
+            transforms=processors.vae_transform,
+            new_token_ids=processors.new_token_ids,
+        )
+        image_shape = tuple(generation_input["padded_images"].shape[-2:])
+        generation_input = _move_to_device(generation_input, device_obj)
+        with torch.autocast(device_obj.type, enabled=fp16 and device_obj.type == "cuda", dtype=amp_dtype):
+            past_key_values = model.forward_cache_update_vae(
+                model.vae_model, past_key_values, **generation_input
+            )
+
+        generation_input, kv_lens, ropes = model.prepare_vit_images(
+            curr_kvlens=kv_lens,
+            curr_rope=ropes,
+            images=[image],
+            transforms=processors.vit_transform,
+            new_token_ids=processors.new_token_ids,
+        )
+        generation_input = _move_to_device(generation_input, device_obj)
+        with torch.autocast(device_obj.type, enabled=fp16 and device_obj.type == "cuda", dtype=amp_dtype):
+            past_key_values = model.forward_cache_update_vit(past_key_values, **generation_input)
+
+        main_context = {
+            "past_key_values": past_key_values,
+            "kv_lens": kv_lens,
+            "ropes": ropes,
+        }
+        return image_shape
+
+    target_shape = _update_context(input_image)
+    _update_context(ref_image)
+
+    cfg_text_context = _clone_context(main_context)
+    cfg_img_context = _clone_context(main_context)
+
+    generation_input = model.prepare_vae_latent(
+        curr_kvlens=main_context["kv_lens"],
+        curr_rope=main_context["ropes"],
+        image_sizes=[target_shape],
+        new_token_ids=processors.new_token_ids,
+    )
+    generation_input = _move_to_device(generation_input, device_obj)
+
+    generation_input_cfg_text = model.prepare_vae_latent_cfg(
+        curr_kvlens=cfg_text_context["kv_lens"],
+        curr_rope=cfg_text_context["ropes"],
+        image_sizes=[target_shape],
+    )
+    generation_input_cfg_text = _move_to_device(generation_input_cfg_text, device_obj)
+
+    generation_input_cfg_img = model.prepare_vae_latent_cfg(
+        curr_kvlens=cfg_img_context["kv_lens"],
+        curr_rope=cfg_img_context["ropes"],
+        image_sizes=[target_shape],
+    )
+    generation_input_cfg_img = _move_to_device(generation_input_cfg_img, device_obj)
+
+    timestep_shift = getattr(model.config, "timestep_shift", 1.0)
+
+    with torch.autocast(device_obj.type, enabled=fp16 and device_obj.type == "cuda", dtype=amp_dtype):
+        latents = model.generate_image(
+            past_key_values=main_context["past_key_values"],
+            cfg_text_past_key_values=cfg_text_context["past_key_values"],
+            cfg_img_past_key_values=cfg_img_context["past_key_values"],
+            num_timesteps=num_timesteps,
+            cfg_text_scale=cfg_text_scale,
+            cfg_img_scale=cfg_img_scale,
+            cfg_interval=cfg_interval,
+            cfg_renorm_min=0.0,
+            cfg_renorm_type="global",
+            timestep_shift=timestep_shift,
+            **generation_input,
+            cfg_text_packed_position_ids=generation_input_cfg_text["cfg_packed_position_ids"],
+            cfg_text_packed_query_indexes=generation_input_cfg_text["cfg_packed_query_indexes"],
+            cfg_text_key_values_lens=generation_input_cfg_text["cfg_key_values_lens"],
+            cfg_text_packed_key_value_indexes=generation_input_cfg_text["cfg_packed_key_value_indexes"],
+            cfg_img_packed_position_ids=generation_input_cfg_img["cfg_packed_position_ids"],
+            cfg_img_packed_query_indexes=generation_input_cfg_img["cfg_packed_query_indexes"],
+            cfg_img_key_values_lens=generation_input_cfg_img["cfg_key_values_lens"],
+            cfg_img_packed_key_value_indexes=generation_input_cfg_img["cfg_packed_key_value_indexes"],
+        )
+
+    latent = latents[0]
+    return _decode_latent(latent, target_shape, model)
+
+
+def glob_pairs(dataset_root: str) -> List[Tuple[str, str, str]]:
+    """Return (reference, input, ground_truth) triples from *dataset_root*."""
+
+    root = Path(dataset_root)
+    ref_dir = root / "breast"
+    in_dir = root / "input"
+    gt_dir = root / "output"
+
+    ids = sorted(p.stem for p in in_dir.glob("*.png"))
+    triples: List[Tuple[str, str, str]] = []
+    for sample_id in ids:
+        triples.append(
+            (
+                str(ref_dir / f"{sample_id}.png"),
+                str(in_dir / f"{sample_id}.png"),
+                str(gt_dir / f"{sample_id}.png"),
+            )
+        )
+    return triples
+
+
+@torch.no_grad()
+def run_batch(
+    model,
+    processors: InferenceProcessors,
+    dataset_root: str,
+    save_dir: str,
+    *,
+    device: str = "cuda",
+    fp16: bool = True,
+    num_timesteps: int = 30,
+    cfg_text_scale: float = 1.0,
+    cfg_img_scale: float = 1.0,
+    cfg_interval: Tuple[float, float] = (0.0, 1.0),
+) -> List[Tuple[str, str, str]]:
+    """Run inference on every pair in *dataset_root* and save predictions."""
+
+    os.makedirs(save_dir, exist_ok=True)
+    pred_dir = os.path.join(save_dir, "preds")
+    os.makedirs(pred_dir, exist_ok=True)
+
+    triples = glob_pairs(dataset_root)
+    results: List[Tuple[str, str, str]] = []
+    for ref_path, in_path, gt_path in triples:
+        sample_id = Path(in_path).stem
+        pred = predict_single_edit(
+            model,
+            processors,
+            ref_path,
+            in_path,
+            device=device,
+            fp16=fp16,
+            num_timesteps=num_timesteps,
+            cfg_text_scale=cfg_text_scale,
+            cfg_img_scale=cfg_img_scale,
+            cfg_interval=cfg_interval,
+        )
+        out_path = os.path.join(pred_dir, f"{sample_id}.png")
+        pred.save(out_path)
+        results.append((out_path, gt_path, sample_id))
+    return results

--- a/scripts/infer_edit.py
+++ b/scripts/infer_edit.py
@@ -1,0 +1,94 @@
+"""Run Bagel reference-guided inference over the breast-edit dataset."""
+from __future__ import annotations
+
+import argparse
+
+from bagel_infer.factory import (
+    build_model,
+    build_processors,
+    load_checkpoint,
+    resolve_checkpoint_dir,
+)
+from bagel_infer.pipeline import run_batch
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bagel breast-edit inference")
+    parser.add_argument("--checkpoint_root", required=True, help="Directory with step checkpoints")
+    parser.add_argument("--step", type=int, default=None, help="Optional checkpoint step; defaults to latest")
+    parser.add_argument("--model_path", required=True, help="Path to fine-tuned Bagel model directory")
+    parser.add_argument("--llm_path", required=True, help="Path to Qwen2 checkpoint")
+    parser.add_argument("--vit_path", required=True, help="Path to SigLIP vision checkpoint")
+    parser.add_argument("--vae_path", required=True, help="Path to VAE weights (ae.safetensors)")
+    parser.add_argument("--dataset_root", required=True, help="Root of breast-edit dataset with breast/input/output")
+    parser.add_argument("--save_dir", required=True, help="Directory to store predictions")
+    parser.add_argument("--device", default="cuda", help="Device to run inference on")
+    parser.add_argument("--fp16", action="store_true", help="Enable FP16/bfloat16 autocast on CUDA")
+    parser.add_argument("--num_timesteps", type=int, default=30, help="Number of denoising steps")
+    parser.add_argument("--cfg_text_scale", type=float, default=1.0, help="Text guidance scale (keep 1.0 for no CFG)")
+    parser.add_argument("--cfg_img_scale", type=float, default=1.0, help="Image guidance scale (keep 1.0 for no CFG)")
+    parser.add_argument(
+        "--cfg_interval",
+        type=float,
+        nargs=2,
+        default=(0.0, 1.0),
+        metavar=("START", "END"),
+        help="Interval (fraction of steps) to apply CFG",
+    )
+    parser.add_argument("--vae_max_image_size", type=int, default=512)
+    parser.add_argument("--vae_min_image_size", type=int, default=256)
+    parser.add_argument("--vae_image_stride", type=int, default=16)
+    parser.add_argument("--vit_max_image_size", type=int, default=350)
+    parser.add_argument("--vit_min_image_size", type=int, default=224)
+    parser.add_argument("--vit_image_stride", type=int, default=14)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    ckpt_dir = resolve_checkpoint_dir(args.checkpoint_root, args.step)
+    print(f"[infer] using checkpoint dir: {ckpt_dir}")
+
+    processors = build_processors(
+        args.llm_path,
+        vae_kwargs=dict(
+            max_image_size=args.vae_max_image_size,
+            min_image_size=args.vae_min_image_size,
+            image_stride=args.vae_image_stride,
+        ),
+        vit_kwargs=dict(
+            max_image_size=args.vit_max_image_size,
+            min_image_size=args.vit_min_image_size,
+            image_stride=args.vit_image_stride,
+        ),
+    )
+
+    model = build_model(
+        model_path=args.model_path,
+        llm_path=args.llm_path,
+        vit_path=args.vit_path,
+        vae_path=args.vae_path,
+        device=args.device,
+        max_latent_size=64,
+        latent_patch_size=2,
+        vit_max_num_patch_per_side=30,
+    )
+    load_checkpoint(model, ckpt_dir)
+
+    run_batch(
+        model=model,
+        processors=processors,
+        dataset_root=args.dataset_root,
+        save_dir=args.save_dir,
+        device=args.device,
+        fp16=args.fp16,
+        num_timesteps=args.num_timesteps,
+        cfg_text_scale=args.cfg_text_scale,
+        cfg_img_scale=args.cfg_img_scale,
+        cfg_interval=tuple(args.cfg_interval),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a lightweight `bagel_infer` package with helpers to build models/processors and run single/batch image inference
- provide a scripted pipeline that mirrors the training data flow to generate breast-edit predictions on demand
- ship a CLI (`scripts/infer_edit.py`) to run batch inference over the dataset with configurable precision and CFG settings

## Testing
- python -m compileall bagel_infer scripts/infer_edit.py

------
https://chatgpt.com/codex/tasks/task_e_68ca6a2a5f6483238c52aa0fe2dfe0a8