### PR TITLE
Align inference config toggles and checkpoint selection

### DIFF
--- a/scripts/export_inference_ckpt.py
+++ b/scripts/export_inference_ckpt.py
@@ -1,0 +1,32 @@
+"""Export a consolidated Bagel inference checkpoint."""
+import os
+
+from safetensors.torch import save_file
+
+from bagel_infer.factory import build_model, load_checkpoint
+
+
+def main() -> None:
+    out = os.environ.get("OUT", "inference.safetensors")
+    model = build_model(
+        model_path="/workspace/Bagel/models/BAGEL-7B-MoT",
+        llm_path="/workspace/models/Qwen2.5-0.5B-Instruct",
+        vit_path="/workspace/models/siglip-so400m-14-980-flash-attn2-navit",
+        vae_path="/workspace/Bagel/flux/vae/ae.safetensors",
+        device="cpu",
+        max_latent_size=64,
+        latent_patch_size=2,
+        vit_max_num_patch_per_side=30,
+    )
+    load_checkpoint(
+        model,
+        "/workspace/Bagel/results/breast_edit_min/checkpoints/0002000",
+        prefer_ema=True,
+    )
+    state_dict = {k: v.cpu() for k, v in model.state_dict().items()}
+    save_file(state_dict, out)
+    print("wrote", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/infer_edit.py
+++ b/scripts/infer_edit.py
@@ -27,6 +27,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--input_path", help="Optional single input image path (bypasses dataset mode)")
     parser.add_argument("--out_name", default="pred.png", help="Output filename for single-pair mode")
     parser.add_argument("--device", default="cuda", help="Device to run inference on")
+    parser.add_argument(
+        "--use_ema",
+        action="store_true",
+        help="Prefer EMA checkpoint weights instead of model.safetensors",
+    )
     parser.add_argument("--fp16", action="store_true", help="Enable FP16/bfloat16 autocast on CUDA")
     parser.add_argument("--num_timesteps", type=int, default=30, help="Number of denoising steps")
     parser.add_argument("--cfg_text_scale", type=float, default=1.0, help="Text guidance scale (keep 1.0 for no CFG)")
@@ -81,7 +86,7 @@ def main() -> None:
     print(
         f"[infer] built LLM hidden={model.language_model.config.hidden_size} (from --llm_path)"
     )
-    load_checkpoint(model, ckpt_dir)
+    load_checkpoint(model, ckpt_dir, prefer_ema=args.use_ema)
 
     if args.ref_path and args.input_path:
         from bagel_infer.pipeline import predict_single_edit


### PR DESCRIPTION
## Summary
- update the inference factory to keep Qwen qk-norm enabled, disable SigLIP ROPE like training, and prefer consolidated checkpoints unless EMA weights are requested
- add a `--use_ema` switch to the inference CLI so checkpoint preference is controllable at runtime
- provide a helper script for exporting a single safetensors file that merges base weights with the fine-tuned connector

## Testing
- python -m compileall bagel_infer scripts

------
https://chatgpt.com/codex/tasks/task_e_68ca768e481083239da7e76152a98420