### PR TITLE
Restore bagel_infer glob_pairs export

### DIFF
--- a/bagel_infer/__init__.py
+++ b/bagel_infer/__init__.py
@@ -7,7 +7,17 @@ from .factory import (
     load_checkpoint,
     resolve_checkpoint_dir,
 )
-from .pipeline import predict_single_edit, run_batch, glob_pairs
+from .pipeline import glob_examples, predict_single_edit, run_batch
+
+# Backwards compatibility: earlier versions exposed ``glob_pairs`` which
+# returned (reference, input) tuples. The new ``glob_examples`` additionally
+# surfaces optional ground-truth paths. Re-export ``glob_pairs`` so external
+# callers expecting the old symbol continue to work.
+def glob_pairs(dataset_root):
+    """Compatibility wrapper for :func:`glob_examples`."""
+
+    triples = glob_examples(dataset_root)
+    return [(ref_path, input_path) for ref_path, input_path, _ in triples]
 
 __all__ = [
     "InferenceProcessors",
@@ -17,5 +27,6 @@ __all__ = [
     "resolve_checkpoint_dir",
     "predict_single_edit",
     "run_batch",
+    "glob_examples",
     "glob_pairs",
 ]


### PR DESCRIPTION
## Summary
- re-export `glob_examples` from `bagel_infer` to match the pipeline implementation
- add a compatibility `glob_pairs` wrapper so existing callers keep working

## Testing
- ❌ `python - <<'PY'
import bagel_infer
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ca7a4769f88323ba578434a5cc8000