### PR TITLE
Use offline SigLIP configs and processors

### DIFF
--- a/scripts/infer_edit.py
+++ b/scripts/infer_edit.py
@@ -61,6 +61,7 @@ def main() -> None:
 
     processors = build_processors(
         args.llm_path,
+        args.vit_path,
         vae_kwargs=dict(
             max_image_size=args.vae_max_image_size,
             min_image_size=args.vae_min_image_size,


### PR DESCRIPTION
## Summary
- ensure AutoConfig lookups for the LLM and vision towers stay offline and avoid remote code
- expose a locally loaded AutoImageProcessor when building inference processors
- update the inference script to pass the SigLIP checkpoint path into the processor factory

## Testing
- python - <<'PY'
from transformers import AutoConfig, AutoImageProcessor
p="/workspace/models/siglip-so400m-14-980-flash-attn2-navit"
print("cfg:", AutoConfig.from_pretrained(p, local_files_only=True, trust_remote_code=False).model_type)
print("proc:", type(AutoImageProcessor.from_pretrained(p, local_files_only=True, trust_remote_code=False)).__name__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cabb9286748323b8d657a97ca7456f