### PR TITLE
Restore Bagel generate path in inference pipeline

### DIFF
--- a/scripts/infer_edit.py
+++ b/scripts/infer_edit.py
@@ -95,13 +95,13 @@ def main() -> None:
         os.makedirs(args.save_dir, exist_ok=True)
         pred = predict_single_edit(
             model,
-            processors.image_processor,
+            processors,
             args.ref_path,
             args.input_path,
             device=args.device,
             fp16=args.fp16,
         )
-        tag = getattr(pred, "_debug_tag", "abs_direct")
+        tag = getattr(pred, "_debug_tag", "bagel_generate")
         base, ext = os.path.splitext(args.out_name)
         out_path = os.path.join(args.save_dir, f"{base}__{tag}{ext}")
         pred.save(out_path)


### PR DESCRIPTION
## Summary
- reimplement the inference pipeline to stream VAE and ViT tokens through Bagel helpers and decode latents via the VAE
- add helper utilities for moving inputs to device, cloning caches, and decoding generated latents
- update CLI inference script to call the new pipeline signature and align debug tags

## Testing
- python -m compileall bagel_infer/pipeline.py scripts/infer_edit.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0fe3760c832384a91a286851e499